### PR TITLE
Upstream changes: Allow hostnames

### DIFF
--- a/lib/gelf_logger.ex
+++ b/lib/gelf_logger.ex
@@ -40,14 +40,15 @@ defmodule Logger.Backends.Gelf do
     
     {:ok, hostname} = :inet.gethostname
 
-    {:ok, gl_host } = Keyword.get(config, :host) |> to_char_list |> :inet_parse.address
+    {:ok, {:hostent, _, _, _, _, addr_list}} = Keyword.get(config, :host) |> to_char_list |> :inet.gethostbyname
+
     port            = Keyword.get(config, :port)
     application     = Keyword.get(config, :application)
     level           = Keyword.get(config, :level)
     metadata        = Keyword.get(config, :metadata, [])
     compression     = Keyword.get(config, :compression, :gzip)
 
-    %{name: name, gl_host: gl_host, host: to_string(hostname), port: port, metadata: metadata, level: level, application: application, socket: socket, compression: compression}
+    %{name: name, gl_host: List.first(addr_list), host: to_string(hostname), port: port, metadata: metadata, level: level, application: application, socket: socket, compression: compression}
   end
 
   defp log_event(level, msg, ts, md, state) do
@@ -115,7 +116,7 @@ defmodule Logger.Backends.Gelf do
   defp make_chunk(payload, id, num, seq) do
     bin = :binary.encode_unsigned(seq)
     
-    <<0x1e, 0x0f, id :: binary - size(8), bin :: binary - size(1), num :: binary - size(1), payload :: binary >>
+    << 0x1e, 0x0f, id :: binary - size(8), bin :: binary - size(1), num :: binary - size(1), payload :: binary >>
   end
 
   defp compress(data, type) do

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule GelfLogger.Mixfile do
 
   def project do
     [app: :gelf_logger,
-     version: "0.2.1",
+     version: "0.3.0",
      elixir: "~> 1.1",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,


### PR DESCRIPTION
https://trello.com/c/4jhZ2WWG/603-docker-investigate-why-graylog-dns-name-is-not-available-within-docker-image
